### PR TITLE
Bug #201457[Enrollment details - if user has selected 'unenrolled' and filled info , then also progress bar considering the enrolled fields as empty and progress bar behaving accordingly]

### DIFF
--- a/apps/front-end/src/pages/front-end/BenificiaryEnrollment.js
+++ b/apps/front-end/src/pages/front-end/BenificiaryEnrollment.js
@@ -80,7 +80,11 @@ export default function BenificiaryEnrollment() {
           </HStack>
           <Box>
             {benificiary?.program_beneficiaries?.enrollment_status ===
-            "not_enrolled" ? (
+              "not_enrolled" ||
+            benificiary?.program_beneficiaries?.enrollment_status ===
+              "applied_but_pending" ||
+            benificiary?.program_beneficiaries?.enrollment_status ===
+              "enrollment_rejected" ? (
               <Progress value={100} size="xs" colorScheme="info" />
             ) : (
               <Progress


### PR DESCRIPTION
-changed condition for progressbar value in enrollment details of benificiary

https://tracker.tekdi.net/issues/201457?tab=time_entries