### PR TITLE
Revert "Bug #210798 (Reopened): [WEB-UI] Captured photo looks Stretched for both learner and prerak attendance."

### DIFF
--- a/lib/common-lib/src/components/Camera.js
+++ b/lib/common-lib/src/components/Camera.js
@@ -49,6 +49,8 @@ export default function Camera({
 
   const capture = async () => {
     const screenshot = webcamRef.current.getScreenshot({
+      width: 640,
+      height: 480,
       screenshotFormat: 'image/webp',
       screenshotQuality: '1'
     })


### PR DESCRIPTION
Reverts tekdi/eg-website#932