### PR TITLE
Bug #211626 [WEB] camp execution -> Leaner attendance -> If Photo is not taken then it's sending '-' for backend and it's creating issue

### DIFF
--- a/apps/front-end/src/pages/front-end/Camp/CampExecution/CampAttendance.js
+++ b/apps/front-end/src/pages/front-end/Camp/CampExecution/CampAttendance.js
@@ -91,7 +91,7 @@ export default function CampAttendance({ activityId }) {
         if (status === PRESENT && randomAttendance) {
           const photo_1 =
             cameraFile?.data?.insert_documents?.returning?.[0]?.name;
-          payLoad = { ...payLoad, photo_1: `${photo_1}` };
+          payLoad = { ...payLoad, photo_1: photo_1 ? `${photo_1}` : null };
         }
         await campService.updateCampAttendance(payLoad);
         await getData();
@@ -100,14 +100,14 @@ export default function CampAttendance({ activityId }) {
       if (status === PRESENT) {
         const photo_1 = randomAttendance
           ? cameraFile?.data?.insert_documents?.returning?.[0]?.name
-          : "-";
-        if (photo_1) {
+          : null;
+        if (activityId) {
           const payLoad = {
             ...data,
             context_id: activityId,
             user_id: user?.id,
             status: PRESENT,
-            photo_1: `${photo_1}`,
+            photo_1: photo_1 ? `${photo_1}` : null,
           };
           await campService.markCampAttendance(payLoad);
           await getData();


### PR DESCRIPTION

<!-- Please keep this section. It will make the maintainer's life easier. -->
### I have ensured that following `Pull Request Checklist` is taken care of before sending this PR
* [ ] Code is formatted as per format decided
* [ ] Updated acceptance criteria in tracker
* [ ] Updated test cases in test-cases-tracker
https://tracker.tekdi.net/issues/211626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the robustness of photo handling and attendance updating in the camp execution feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->