### PR TITLE
Bug #213035 [WEB ADMIN]: Learners enrollment name is showing before enorllment verification

### DIFF
--- a/apps/front-end/src/pages/admin/beneficiaries/Profile.js
+++ b/apps/front-end/src/pages/admin/beneficiaries/Profile.js
@@ -534,11 +534,9 @@ export default function AgAdminProfile({ footerLinks }) {
               overflow="hidden"
               textOverflow="ellipsis"
             >
-              {[
-                "enrolled",
-                "enrolled_ip_verified",
-                "registered_in_camp",
-              ].includes(data?.program_beneficiaries?.status)
+              {["enrolled_ip_verified", "registered_in_camp"].includes(
+                data?.program_beneficiaries?.status
+              )
                 ? `${
                     data?.program_beneficiaries?.enrollment_first_name ?? "-"
                   } ${data?.program_beneficiaries?.enrollment_last_name ?? "-"}`


### PR DESCRIPTION

<!-- Please keep this section. It will make the maintainer's life easier. -->
### I have ensured that following `Pull Request Checklist` is taken care of before sending this PR
* [ ] Code is formatted as per format decided
* [ ] Updated acceptance criteria in tracker
* [ ] Updated test cases in test-cases-tracker
https://tracker.tekdi.net/issues/213035

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the conditions for displaying beneficiary information to correctly include those with "enrolled_ip_verified" status and exclude those only marked as "enrolled."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->