### PR TITLE
Bug #226389 Benificiary Profile view showing white screen. Getting `GetOptions` not defined

### DIFF
--- a/apps/front-end/src/pages/admin/beneficiaries/Profile.js
+++ b/apps/front-end/src/pages/admin/beneficiaries/Profile.js
@@ -2180,9 +2180,3 @@ AgAdminProfile.propTypes = {
   footerLinks: PropTypes.any,
   userTokenInfo: PropTypes.any,
 };
-
-GetOptions.propTypes = {
-  array: PropTypes.array,
-  enumType: PropTypes.string,
-  enumApiData: PropTypes.object,
-};


### PR DESCRIPTION
https://tracker.tekdi.net/issues/226389

<!-- Please keep this section. It will make the maintainer's life easier. -->
### I have ensured that following `Pull Request Checklist` is taken care of before sending this PR
* [ ] Code is formatted as per format decided
* [ ] Updated acceptance criteria in tracker
* [ ] Updated test cases in test-cases-tracker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed obsolete prop type declarations for the `GetOptions` component in the `AgAdminProfile`, improving clarity and reducing potential errors in data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->